### PR TITLE
fix: add fetched_at to ap_shipment_tracking key

### DIFF
--- a/tap_shipstation/__init__.py
+++ b/tap_shipstation/__init__.py
@@ -68,7 +68,7 @@ def discover():
     keys = {
         'shipments': ['shipment_id'],
         'fulfillments': ['fulfillment_id'],
-        'ap_shipment_tracking': ['shipment_id']
+        'ap_shipment_tracking': ['shipment_id', 'fetched_at']
     }
 
     for schema_name, schema in raw_schemas.items():


### PR DESCRIPTION
Adds `fetched_at` to the Singer key_properties so target-postgres appends history instead of upserting on `shipment_id` alone. Without history, downstream dedup logic for the AP delivery alerts cannot pin `actual_delivery_date` to first delivery detection.